### PR TITLE
Define core models and update auth adapter

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,20 @@
+import NextAuth, { NextAuthOptions } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+
+import prisma from "@/lib/prisma";
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+};
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/test-auth/route.ts
+++ b/app/api/test-auth/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "../auth/[...nextauth]/route";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json(session);
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      "app/generated/**",
     ],
   },
 ];

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as typeof globalThis & {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error", "warn"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;

--- a/prisma/migrations/20250924143722_add_models/migration.sql
+++ b/prisma/migrations/20250924143722_add_models/migration.sql
@@ -1,0 +1,88 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Event` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Account" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+    CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Account" ("access_token", "expires_at", "id", "id_token", "provider", "providerAccountId", "refresh_token", "scope", "session_state", "token_type", "type", "userId") SELECT "access_token", "expires_at", "id", "id_token", "provider", "providerAccountId", "refresh_token", "scope", "session_state", "token_type", "type", "userId" FROM "Account";
+DROP TABLE "Account";
+ALTER TABLE "new_Account" RENAME TO "Account";
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+CREATE TABLE "new_Event" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "uid" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "startUtc" DATETIME NOT NULL,
+    "endUtc" DATETIME,
+    "timezone" TEXT,
+    "venueName" TEXT,
+    "address" TEXT,
+    "lat" REAL,
+    "lng" REAL,
+    "category" TEXT,
+    "tag" TEXT NOT NULL DEFAULT 'Other',
+    "url" TEXT,
+    "createdByUser" BOOLEAN NOT NULL DEFAULT false,
+    "city" TEXT,
+    "country" TEXT,
+    "status" TEXT,
+    "lastSeenAtUtc" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Event_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Event" ("address", "category", "city", "country", "createdByUser", "description", "endUtc", "id", "lastSeenAtUtc", "lat", "lng", "source", "startUtc", "status", "tag", "timezone", "title", "uid", "url", "userId", "venueName") SELECT "address", "category", "city", "country", "createdByUser", "description", "endUtc", "id", "lastSeenAtUtc", "lat", "lng", "source", "startUtc", "status", "tag", "timezone", "title", "uid", "url", "userId", "venueName" FROM "Event";
+DROP TABLE "Event";
+ALTER TABLE "new_Event" RENAME TO "Event";
+CREATE UNIQUE INDEX "Event_userId_uid_key" ON "Event"("userId", "uid");
+CREATE TABLE "new_Integration" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "lastSyncAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Integration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Integration" ("createdAt", "enabled", "id", "lastSyncAt", "provider", "updatedAt", "userId") SELECT "createdAt", "enabled", "id", "lastSyncAt", "provider", "updatedAt", "userId" FROM "Integration";
+DROP TABLE "Integration";
+ALTER TABLE "new_Integration" RENAME TO "Integration";
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" DATETIME,
+    "image" TEXT,
+    "timeZone" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("email", "id", "image", "name", "timeZone") SELECT "email", "id", "image", "name", "timeZone" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,19 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
-generator client {
-  provider = "prisma-client-js"
-  output   = "../app/generated/prisma"
-}
-
-datasource db {
-  provider = "sqlite"
-  url      = env("DATABASE_URL")
-}
-
 generator client {
   provider = "prisma-client-js"
   output   = "../app/generated/prisma"
@@ -30,9 +14,10 @@ model User {
   email         String?       @unique
   emailVerified DateTime?
   image         String?
+  timeZone      String?
   accounts      Account[]
   integrations  Integration[]
-  events        Event[]       @relation("UserEvents")
+  events        Event[]
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
 }
@@ -56,32 +41,41 @@ model Account {
 }
 
 model Integration {
-  id              String   @id @default(cuid())
-  userId          String
-  provider        String
-  externalId      String
-  accessToken     String?
-  refreshToken    String?
-  expiresAt       DateTime?
-  metadata        Json?
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  events          Event[]
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-
-  @@unique([provider, externalId])
+  id         String   @id @default(cuid())
+  userId     String
+  provider   String
+  enabled    Boolean  @default(true)
+  lastSyncAt DateTime?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Event {
-  id             String        @id @default(cuid())
+  id             String   @id @default(cuid())
   userId         String
-  integrationId  String?
+  uid            String
+  source         String
   title          String
   description    String?
-  payload        Json?
-  occurredAt     DateTime      @default(now())
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
-  user           User          @relation("UserEvents", fields: [userId], references: [id], onDelete: Cascade)
-  integration    Integration?  @relation(fields: [integrationId], references: [id], onDelete: SetNull)
+  startUtc       DateTime
+  endUtc         DateTime?
+  timezone       String?
+  venueName      String?
+  address        String?
+  lat            Float?
+  lng            Float?
+  category       String?
+  tag            String   @default("Other")
+  url            String?
+  createdByUser  Boolean  @default(false)
+  city           String?
+  country        String?
+  status         String?
+  lastSeenAtUtc  DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, uid])
 }


### PR DESCRIPTION
## Summary
- define the Prisma schema for users, accounts, integrations, and events against the SQLite datasource
- add the generated migration to align the SQLite database with the new schema
- update the NextAuth handler to import the Prisma adapter from `@auth/prisma-adapter`

## Testing
- npx prisma migrate dev --name add_models
- npx prisma generate
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d4004e8560832889191174f07c5e57